### PR TITLE
Fix audio pipeline overflow assertion in tests

### DIFF
--- a/components/CallScreen.tsx
+++ b/components/CallScreen.tsx
@@ -125,7 +125,10 @@ const CallScreen: React.FC<CallScreenProps> = ({ onEndCall, config }) => {
         const inputData = event.inputBuffer.getChannelData(0);
         // Using GenAIBlob type alias for clarity and to avoid conflict with DOM Blob
         const pcmBlob: GenAIBlob = {
-          data: encode(new Uint8Array(new Int16Array(inputData.map(x => x * 32768)).buffer)),
+          data: encode(new Uint8Array(new Int16Array(inputData.map(x => {
+            const scaled = Math.round(x * 32767);
+            return Math.max(-32768, Math.min(32767, scaled));
+          })).buffer)),
           mimeType: 'audio/pcm;rate=16000',
         };
         sessionPromiseRef.current?.then((session) => {


### PR DESCRIPTION
…erflow

Production code was using x * 32768 without clamping, causing overflow at boundary values (1.0 would wrap to -32768). Changed to scale by 32767 with proper clamping to [-32768, 32767] range.

Updated tests to use the same clamping logic and assert all converted values, ensuring consistency between the two microphone input tests.

## Summary by Sourcery

Align audio pipeline PCM conversion with production clamping to avoid Int16 overflow at boundary values.

Bug Fixes:
- Prevent Int16 overflow when converting Float32 microphone samples to PCM by clamping scaled values to [-32768, 32767].

Tests:
- Update microphone input integration tests to use the same clamping logic as production and assert all converted sample values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone audio encoding for more consistent and reliable audio capture quality during calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->