### PR TITLE
Fix Vitest globals configuration in tsconfig

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,9 +6,12 @@ import { TextEncoder, TextDecoder } from 'util';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as typeof global.TextDecoder;
 
-// Mock process.env for tests
+// Mock process.env for tests in a minimally intrusive way
+const originalProcess = process;
 vi.stubGlobal('process', {
+  ...originalProcess,
   env: {
+    ...originalProcess.env,
     API_KEY: 'test-api-key',
     GEMINI_API_KEY: 'test-gemini-api-key',
   },
@@ -22,25 +25,23 @@ class MockAudioContext {
   destination = {};
 
   createBuffer(channels: number, length: number, sampleRate: number) {
-    const buffer = {
+    return {
       numberOfChannels: channels,
       length,
       sampleRate,
       duration: length / sampleRate,
       getChannelData: vi.fn(() => new Float32Array(length)),
     };
-    return buffer;
   }
 
   createBufferSource() {
-    const source = {
+    return {
       buffer: null as any,
       connect: vi.fn(),
       start: vi.fn(),
       stop: vi.fn(),
       onended: null as (() => void) | null,
     };
-    return source;
   }
 
   createMediaStreamSource() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node",
-      "vitest/globals"
+      "node"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals"]
+  },
+  "include": [
+    "vitest.config.*",
+    "tests/**/*",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
+    typecheck: {
+      tsconfig: './tsconfig.test.json',
+    },
     include: ['**/*.test.{ts,tsx}'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
- Remove vitest/globals from main tsconfig.json to prevent test globals from leaking into production code
- Create tsconfig.test.json that extends base config and adds vitest globals only for test files
- Update vitest.config.ts to use tsconfig.test.json for typechecking
- Preserve original process properties in test setup mock to avoid breaking code that relies on process.cwd(), nextTick, etc.
- Inline immediately-returned variables in MockAudioContext methods

## Summary by Sourcery

Scope Vitest globals and type checking to tests while making the test environment mocks less intrusive.

Bug Fixes:
- Preserve original Node.js process properties in the test process mock to avoid breaking code that relies on them.

Enhancements:
- Inline MockAudioContext helper variables for simpler test audio context mocks.

Build:
- Introduce a dedicated tsconfig.test.json that extends the main TypeScript config for tests and configures Vitest type checking to use it.
- Remove Vitest global types from the main tsconfig.json so test globals do not leak into production code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with TypeScript type checking capabilities to improve test reliability and error detection.

* **Chores**
  * Optimized test environment configuration and setup with improved process and environment variable mocking to ensure consistent test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->